### PR TITLE
Added limit support and changed the datetime data type to the sql datetime2

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -322,7 +322,7 @@ function sqlTypeCast(type) {
       return 'DATE';
 
     case 'datetime':
-      return 'DATETIME';
+      return 'DATETIME2';
 
     default:
       console.error("Unregistered type given: " + type);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,6 +63,10 @@ utils.buildSelectStatement = function(criteria, table) {
   if(criteria.groupBy || criteria.sum || criteria.average || criteria.min || criteria.max) {
     query = 'SELECT ';
 
+    if(criteria.limit){
+        query += 'TOP ' + criteria.limit + ' ';
+    }
+
     // Append groupBy columns to select statement
     if(criteria.groupBy) {
       if(criteria.groupBy instanceof Array) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,9 +131,15 @@ utils.buildSelectStatement = function(criteria, table) {
     query = query.slice(0, -2) + ' ';
 
     // Add FROM clause
-    return query += 'FROM ' + table + ' ';
+    return util.format(query + 'FROM [%s] ',table);
+
   }
 
   // Else select ALL
-  return util.format('SELECT * FROM [%s] ', table);
+  var query = 'SELECT ';
+  if (criteria.limit){
+  query += 'TOP ' + criteria.limit + ' ';
+  }
+  
+  return util.format(query +'* FROM [%s] ', table);
 };


### PR DESCRIPTION
Datetime2 allows millisecond comparisons (i.e. the granularity of the JS date object)
